### PR TITLE
COM Dialog: isosurface enables isovalue/opacity

### DIFF
--- a/avogadro/qtplugins/coloropacitymap/comdialog.ui
+++ b/avogadro/qtplugins/coloropacitymap/comdialog.ui
@@ -76,6 +76,9 @@
      </item>
      <item row="3" column="1">
       <widget class="QDoubleSpinBox" name="isoValue">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
        <property name="decimals">
         <number>3</number>
        </property>
@@ -96,6 +99,9 @@
      </item>
      <item row="4" column="1">
       <widget class="QDoubleSpinBox" name="opacity">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
        <property name="maximum">
         <double>1.000000000000000</double>
        </property>
@@ -120,5 +126,38 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>enableIsosurface</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>isoValue</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>472</x>
+     <y>465</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>472</x>
+     <y>493</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enableIsosurface</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>opacity</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>472</x>
+     <y>465</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>472</x>
+     <y>525</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
In the color opacity map editor, only enable isovalue/opacity
spin boxes when the isosurface is being shown.

This clarifies that they are only used for the isosurface, and
not the volume rendering.

Signed-off-by: Patrick Avery <psavery@buffalo.edu>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
